### PR TITLE
Fix Octane compatibility: ensure targetStack and config cleanup on exception

### DIFF
--- a/src/AliasStorageProvider.php
+++ b/src/AliasStorageProvider.php
@@ -39,14 +39,14 @@ class AliasStorageProvider extends ServiceProvider
 
         $this->targetStack[] = $target;
 
-        /** @var FilesystemFactory $factory */
-        $factory = $this->app->make(FilesystemFactory::class);
+        try {
+            /** @var FilesystemFactory $factory */
+            $factory = $this->app->make(FilesystemFactory::class);
 
-        $disk = $factory->make($filesystemManager, $target, $config['options'] ?? []);
-
-        array_pop($this->targetStack);
-
-        return $disk;
+            return $factory->make($filesystemManager, $target, $config['options'] ?? []);
+        } finally {
+            array_pop($this->targetStack);
+        }
     }
 
     private function getFilesystemManager(): FilesystemManager

--- a/src/FilesystemFactory.php
+++ b/src/FilesystemFactory.php
@@ -24,10 +24,10 @@ class FilesystemFactory extends FilesystemManager
 
         $repository->set($key, array_merge($backupConfig, $config));
 
-        $fileSystem = $manager->resolve($target);
-
-        $repository->set($key, $backupConfig);
-
-        return $fileSystem;
+        try {
+            return $manager->resolve($target);
+        } finally {
+            $repository->set($key, $backupConfig);
+        }
     }
 }

--- a/tests/AliasStorageTest.php
+++ b/tests/AliasStorageTest.php
@@ -92,4 +92,40 @@ class AliasStorageTest extends TestCase
 
         Storage::disk('bar');
     }
+
+    /**
+     * @see https://github.com/besanek/laravel-alias-storage/issues/5
+     */
+    public function testTargetStackIsCleanedUpAfterException(): void
+    {
+        $this->app['config']->set('filesystems.disks.broken', [
+            'driver' => 'alias',
+            'target' => 'nonexistent_driver_disk',
+        ]);
+
+        $this->app['config']->set('filesystems.disks.nonexistent_driver_disk', [
+            'driver' => 'this_driver_does_not_exist',
+        ]);
+
+        try {
+            Storage::disk('broken');
+            $this->fail('Expected an exception from the invalid driver');
+        } catch (\InvalidArgumentException) {
+            // expected
+        }
+
+        $this->app['config']->set('filesystems.disks.nonexistent_driver_disk', [
+            'driver' => 'local',
+            'root' => storage_path('app'),
+        ]);
+
+        $this->app['config']->set('filesystems.disks.another_alias', [
+            'driver' => 'alias',
+            'target' => 'nonexistent_driver_disk',
+        ]);
+
+        // Without fix: false "cyclic disk aliasing" detection
+        $disk = Storage::disk('another_alias');
+        $this->assertNotNull($disk);
+    }
 }


### PR DESCRIPTION
Wrap disk resolution in try/finally in both AliasStorageProvider and FilesystemFactory so that targetStack is always popped and config is always restored, even when an exception occurs. Without this, a failed resolution in Octane (where the provider persists across requests) leaves stale state that causes false cyclic alias detection.

Closes #5